### PR TITLE
fix(application): add a condition to only render the pagination when the component name equals the name prop, which means that the store has been cleaned up and got the current module data

### DIFF
--- a/src/application/components/branches/BranchesPagination.jsx
+++ b/src/application/components/branches/BranchesPagination.jsx
@@ -6,10 +6,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const BranchesPagination = ({ permissions }) => {
-    const { records, isLoading, error, page, pagesCanBeGenerated, nextPage, previousPage } = useRecordsStorePagination();
+export const BranchesPagination = ({ permissions, name }) => {
+    const { records, isLoading, error, page, pagesCanBeGenerated, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startOpenUpdateModal } = useUIStore();
     const { startSelectingRecord } = useRecordsStoreUpdate();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} page={page} pagesCanBeGenerated={pagesCanBeGenerated} nextPage={nextPage} previousPage={previousPage}>

--- a/src/application/components/customers/CustomersPagination.jsx
+++ b/src/application/components/customers/CustomersPagination.jsx
@@ -8,10 +8,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const CustomersPagination = ({ permissions }) => {
-    const { records, isLoading, error, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const CustomersPagination = ({ permissions, name }) => {
+    const { records, isLoading, error, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage}>
@@ -28,9 +30,9 @@ export const CustomersPagination = ({ permissions }) => {
                             <DataContainer name='Teléfono' data={customer.numTelefono} />
                             <DataContainer name='Dirección' data={customer.direccion} />
                             <DataContainer name='Estatus' data={customer.activo ? 'Activo' : 'Inactivo'} />
-                            <DataContainer name='Creador' data={customer.creador?.nombres} />
+                            <DataContainer name='Creador' data={customer.creador.nombres} />
                             <DataContainer name='Fecha de creación' data={customer.fechaCreacion} convertToDate={true} />
-                            <DataContainer name='Último en modificar' data={customer.ultimoEnModificar?.nombres} />
+                            <DataContainer name='Último en modificar' data={customer.ultimoEnModificar.nombres} />
                             <DataContainer name='Fecha de última modificación' data={customer.fechaUltimaModificacion} convertToDate={true} />
                             {
                                 permissions.find(permission => permission === 'ACTUALIZAR') &&

--- a/src/application/components/productTypes/ProductTypesPagination.jsx
+++ b/src/application/components/productTypes/ProductTypesPagination.jsx
@@ -8,10 +8,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const ProductTypesPagination = ({ permissions }) => {
-    const { records, error, isLoading, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const ProductTypesPagination = ({ permissions, name }) => {
+    const { records, error, isLoading, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage} >

--- a/src/application/components/products/ProductsPagination.jsx
+++ b/src/application/components/products/ProductsPagination.jsx
@@ -8,10 +8,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const ProductsPagination = ({ permissions }) => {
-    const { records, isLoading, error, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const ProductsPagination = ({ permissions, name }) => {
+    const { records, isLoading, error, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage}>
@@ -25,9 +27,9 @@ export const ProductsPagination = ({ permissions }) => {
                             <DataContainer name='Proveedor' data={product.proveedor?.nombre} />
                             <DataContainer name='Venta por' data={product.ventaPor} />
                             <DataContainer name='Estatus' data={product.activo ? 'Activo' : 'Inactivo'} />
-                            <DataContainer name='Creador' data={product.creador?.nombres} />
+                            <DataContainer name='Creador' data={product.creador.nombres} />
                             <DataContainer name='Fecha de creación' data={product.fechaCreacion} convertToDate={true} />
-                            <DataContainer name='Último en modificar' data={product.ultimoEnModificar?.nombres} />
+                            <DataContainer name='Último en modificar' data={product.ultimoEnModificar.nombres} />
                             <DataContainer name='Fecha de última modificación' data={product.fechaUltimaModificacion} convertToDate={true} />
                             {
                                 permissions.find(permission => permission === 'ACTUALIZAR') &&

--- a/src/application/components/providers/ProvidersPagination.jsx
+++ b/src/application/components/providers/ProvidersPagination.jsx
@@ -8,10 +8,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const ProvidersPagination = ({ permissions }) => {
-    const { records, isLoading, error, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const ProvidersPagination = ({ permissions, name }) => {
+    const { records, isLoading, error, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage}>

--- a/src/application/components/purchases/PurchasesPagination.jsx
+++ b/src/application/components/purchases/PurchasesPagination.jsx
@@ -8,10 +8,12 @@ const handleOpenModalAndSelectRecord = (startOpenShowMoreModal, startSelectingRe
     startOpenShowMoreModal();
 }
 
-export const PurchasesPagination = () => {
-    const { records, isLoading, error, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const PurchasesPagination = ({ name }) => {
+    const { records, isLoading, error, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenShowMoreModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage}>
@@ -19,9 +21,9 @@ export const PurchasesPagination = () => {
                 {
                     records?.map(purchase => (
                         <Card key={purchase.id}>
-                            <DataContainer name='Sucursal' data={purchase.sucursal?.nombre} />
-                            <DataContainer name='Creador' data={purchase.creador?.nombres} />
-                            <DataContainer name='Proveedor' data={purchase.proveedor?.nombre} />
+                            <DataContainer name='Sucursal' data={purchase.sucursal.nombre} />
+                            <DataContainer name='Creador' data={purchase.creador.nombres} />
+                            <DataContainer name='Proveedor' data={purchase.proveedor.nombre} />
                             <DataContainer name='Total' data={`$${purchase.total}`} />
                             <DataContainer name='Fecha de creación' data={purchase.fechaCreacion} convertToDate={true} />
                             <Button

--- a/src/application/components/stock/StockPagination.jsx
+++ b/src/application/components/stock/StockPagination.jsx
@@ -8,10 +8,12 @@ const openUpdateModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
     startOpenUpdateModal();
 }
 
-export const StockPagination = ({ permissions }) => {
-    const { records, isLoading, error, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const StockPagination = ({ permissions, name }) => {
+    const { records, isLoading, error, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} isLoading={isLoading} error={error} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage} >
@@ -19,13 +21,13 @@ export const StockPagination = ({ permissions }) => {
                 {
                     records?.map(stock => (
                         <Card key={stock.id}>
-                            <DataContainer name='Sucursal' data={stock.sucursal?.nombre} />
-                            <DataContainer name='Producto' data={stock.producto?.nombre} />
+                            <DataContainer name='Sucursal' data={stock.sucursal.nombre} />
+                            <DataContainer name='Producto' data={stock.producto.nombre} />
                             <DataContainer name='Existencia' data={stock.existencia} />
                             <DataContainer name='Precio' data={`$${stock.precio}`} />
-                            <DataContainer name='Creador' data={stock.creador?.nombres} />
+                            <DataContainer name='Creador' data={stock.creador.nombres} />
                             <DataContainer name='Fecha de creación' data={stock.fechaCreacion} convertToDate={true} />
-                            <DataContainer name='Último en modificar' data={stock.ultimoEnModificar?.nombres} />
+                            <DataContainer name='Último en modificar' data={stock.ultimoEnModificar.nombres} />
                             <DataContainer name='Fecha de última modificación' data={stock.fechaUltimaModificacion} convertToDate={true} />
                             {
                                 permissions.find(permission => permission === 'ACTUALIZAR') &&

--- a/src/application/components/users/UsersPagination.jsx
+++ b/src/application/components/users/UsersPagination.jsx
@@ -7,10 +7,12 @@ const handleOpenModalAndStartSelectingRecord = (startOpenUpdateModal, startSelec
 
     startOpenUpdateModal();
 }
-export const UsersPagination = ({ permissions }) => {
-    const { records, error, isLoading, pagesCanBeGenerated, page, nextPage, previousPage } = useRecordsStorePagination();
+export const UsersPagination = ({ permissions, name }) => {
+    const { records, error, isLoading, pagesCanBeGenerated, page, componentName, nextPage, previousPage } = useRecordsStorePagination();
     const { startSelectingRecord } = useRecordsStoreUpdate();
     const { startOpenUpdateModal } = useUIStore();
+
+    if (componentName !== name) return (<></>);
 
     return (
         <PaginationContainer data={records} error={error} isLoading={isLoading} pagesCanBeGenerated={pagesCanBeGenerated} page={page} nextPage={nextPage} previousPage={previousPage} >
@@ -18,23 +20,23 @@ export const UsersPagination = ({ permissions }) => {
                 {
                     records?.map(usuario => (
                         <Card key={usuario.id}>
-                            <DataContainer name='Nombres' data={usuario?.nombres} />
-                            <DataContainer name='Apellido paterno' data={usuario?.apellidoPaterno} />
-                            <DataContainer name='Apellido materno' data={usuario?.apellidoMaterno} />
-                            <DataContainer name='Rfc' data={usuario?.rfc} />
-                            <DataContainer name='Rol' data={usuario?.rol?.rol} />
+                            <DataContainer name='Nombres' data={usuario.nombres} />
+                            <DataContainer name='Apellido paterno' data={usuario.apellidoPaterno} />
+                            <DataContainer name='Apellido materno' data={usuario.apellidoMaterno} />
+                            <DataContainer name='Rfc' data={usuario.rfc} />
+                            <DataContainer name='Rol' data={usuario.rol.rol} />
                             {
-                                usuario.sucursal && <DataContainer name='Sucursal' data={usuario?.sucursal?.nombre} />
+                                usuario.sucursal && <DataContainer name='Sucursal' data={usuario.sucursal.nombre} />
                             }
-                            <DataContainer name='Email' data={usuario?.email} />
-                            <DataContainer name='Direccion' data={usuario?.direccion} />
-                            <DataContainer name='Teléfono' data={usuario?.numTelefono} />
-                            <DataContainer name='Estatus' data={usuario?.activo ? 'Activo' : 'Inactivo'} />
-                            <DisplayModules name='Módulos' modules={usuario?.modulos} />
-                            <DataContainer name='Creador' data={usuario?.creador?.nombres} />
-                            <DataContainer name='Fecha de creación' data={usuario?.fechaCreacion} convertToDate={true} />
-                            <DataContainer name='Último en modificar' data={usuario?.ultimoEnModificar?.nombres} />
-                            <DataContainer name='Fecha de última modificación' data={usuario?.fechaUltimaModificacion} convertToDate={true} />
+                            <DataContainer name='Email' data={usuario.email} />
+                            <DataContainer name='Direccion' data={usuario.direccion} />
+                            <DataContainer name='Teléfono' data={usuario.numTelefono} />
+                            <DataContainer name='Estatus' data={usuario.activo ? 'Activo' : 'Inactivo'} />
+                            <DisplayModules name='Módulos' modules={usuario.modulos} />
+                            <DataContainer name='Creador' data={usuario.creador.nombres} />
+                            <DataContainer name='Fecha de creación' data={usuario.fechaCreacion} convertToDate={true} />
+                            <DataContainer name='Último en modificar' data={usuario.ultimoEnModificar.nombres} />
+                            <DataContainer name='Fecha de última modificación' data={usuario.fechaUltimaModificacion} convertToDate={true} />
                             {
                                 permissions.find(permission => permission === 'ACTUALIZAR') &&
                                 <Button text='Actualizar' type='button' buttonSyles='w-full' handleClick={() => handleOpenModalAndStartSelectingRecord(startOpenUpdateModal, startSelectingRecord, usuario.sucursal ? { id: usuario.id, nombres: usuario.nombres, apellidoPaterno: usuario.apellidoPaterno, apellidoMaterno: usuario.apellidoMaterno, rfc: usuario.rfc, rol: usuario.rol.id, sucursal: usuario.sucursal.id, email: usuario.email, direccion: usuario.direccion, numTelefono: usuario.numTelefono, activo: usuario.activo, modulos: usuario.modulos.map(module => { return { nombre: module.nombre, componente: module.componente, ruta: module.ruta, permisos: module.permisos } }) } : { id: usuario.id, nombres: usuario.nombres, apellidoPaterno: usuario.apellidoPaterno, apellidoMaterno: usuario.apellidoMaterno, rfc: usuario.rfc, rol: usuario.rol.id, email: usuario.email, direccion: usuario.direccion, numTelefono: usuario.numTelefono, activo: usuario.activo, modulos: usuario.modulos.map(module => { return { nombre: module.nombre, componente: module.componente, ruta: module.ruta, permisos: module.permisos } }) })} />

--- a/src/application/pages/Branches.jsx
+++ b/src/application/pages/Branches.jsx
@@ -25,7 +25,7 @@ export const Branches = ({ permissions, name }) => {
                 (
                     <>
                         <BranchesFilters baseUrl={baseUrl} />
-                        <BranchesPagination permissions={permissions} />
+                        <BranchesPagination permissions={permissions} name={name} />
                     </>
                 )
             }

--- a/src/application/pages/Customers.jsx
+++ b/src/application/pages/Customers.jsx
@@ -23,7 +23,7 @@ export const Customers = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <CustomersFilters baseUrl={baseUrl} />
-                    <CustomersPagination permissions={permissions} />
+                    <CustomersPagination permissions={permissions} name={name} />
                 </>
             }
             {

--- a/src/application/pages/ProductTypes.jsx
+++ b/src/application/pages/ProductTypes.jsx
@@ -23,7 +23,7 @@ export const ProductTypes = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <ProductTypesFilters baseUrl={baseUrl} />
-                    <ProductTypesPagination permissions={permissions} />
+                    <ProductTypesPagination permissions={permissions} name={name} />
                 </>
             }
             {

--- a/src/application/pages/Products.jsx
+++ b/src/application/pages/Products.jsx
@@ -23,7 +23,7 @@ export const Products = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <ProductsFilters baseUrl={baseUrl} />
-                    <ProductsPagination permissions={permissions} />
+                    <ProductsPagination permissions={permissions} name={name} />
                 </>
             }
             {

--- a/src/application/pages/Providers.jsx
+++ b/src/application/pages/Providers.jsx
@@ -21,7 +21,7 @@ export const Providers = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <ProvidersFilters baseUrl={baseUrl} />
-                    <ProvidersPagination permissions={permissions} />
+                    <ProvidersPagination permissions={permissions} name={name} />
                 </>
             }
             {

--- a/src/application/pages/Purchases.jsx
+++ b/src/application/pages/Purchases.jsx
@@ -19,7 +19,7 @@ export const Purchases = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <PurchasesFilters baseUrl={baseUrl} />
-                    <PurchasesPagination />
+                    <PurchasesPagination name={name} />
                 </>
             }
             {

--- a/src/application/pages/Stock.jsx
+++ b/src/application/pages/Stock.jsx
@@ -23,7 +23,7 @@ export const Stock = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <StockFilters baseUrl={baseUrl} />
-                    <StockPagination permissions={permissions} />
+                    <StockPagination permissions={permissions} name={name} />
                 </>
             }
             {

--- a/src/application/pages/Users.jsx
+++ b/src/application/pages/Users.jsx
@@ -23,7 +23,7 @@ export const Users = ({ permissions, name }) => {
                 permissions.find(permission => permission === 'VER') &&
                 <>
                     <UsersFilters baseUrl={baseUrl} />
-                    <UsersPagination permissions={permissions} />
+                    <UsersPagination permissions={permissions} name={name} />
                 </>
             }
             {


### PR DESCRIPTION
## Changes:

* Updated all modules that contain pagination to only return the pagination when the componentName (recordsSlice) equals the name prop (api) of the current module, that means that the store has been cleaned up and got the current module data and not the previous module data.